### PR TITLE
Add shim for support of older versions of node (pre ES6) which does n…

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -51,6 +51,12 @@ Config.prototype.control = function () {
     }
 };
 
+if(!String.prototype.includes) {
+  String.prototype.includes = function(arg) {
+    return this.indexOf(arg) != -1;
+  }
+}
+
 
 function write(args, units, ip) {
 


### PR DESCRIPTION
My older install of Node on my dev machine does not include support for the ES6-introduced 'includes' function on strings.  

This patch adds a shim for the case where the includes function does not exist, making it compatible with more installations.

See issue #16.
