### PR TITLE
feature/2.0.5/arg-printing

### DIFF
--- a/lib/weather/Config.js
+++ b/lib/weather/Config.js
@@ -105,8 +105,17 @@ function config_weather () {
     }
     
     if (args.get("verbose")) {
+        
         console.log();
         console.log(chalk.bold.underline("cli-weather v" + pkg.version));
+        console.log();
+        
+        for (var prop in args.flattened) {
+            if (prop != "key") {
+                console.log(`${prop} = ${typeof(args.get(prop)) === "string" ? args.get(prop) : "true"}`);
+            }
+        }
+        
         console.log();
     }
     


### PR DESCRIPTION
When `--verbose` or `-v` flag is passed, the arguments are printed out.